### PR TITLE
CI: Do not test with python3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
       max-parallel: 1
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist=
-    py{35,36,37,38,39,310-dev},
+    py{36,37,38,39,310-dev},
     flake8,
     mypy
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38


### PR DESCRIPTION
Sphinx-4.0 will be drop the support of python3.5. So this also stops it on CI